### PR TITLE
2024.05.26绯月safeid匹配规则更新

### DIFF
--- a/绯月ScarletMoon.har
+++ b/绯月ScarletMoon.har
@@ -203,7 +203,7 @@
             "extract_variables": [
                 {
                     "name": "safeid",
-                    "re": "safeid=(.+?)&",
+                    "re": "safeid=([a-zA-Z0-9]+)",
                     "from": "content"
                 },
                 {


### PR DESCRIPTION
2024.05.26绯月safeid匹配规则更新

在登录账户后，签到页面 https://bbs.kfpromax.com/kf_growup.php safeid代码段更新为
\<a href="kf_growup.php?ok=3&amp;safeid=23d1263" target="_self">你可以领取 0KFB + 0经验 + 0贡献 请点击这里</a>
safeid后原有的&取消了

绯月模板旧的匹配规则为safeid=(.+?)&，该匹配规则会导致匹配到的safeid值为空，从而导致签到失败。
ok=(.+?)&可以正常获取数据

此次PR修正了safeid匹配规则，现safeid匹配规则更新为safeid=([a-zA-Z0-9]+)从而可以正常提取safeid值，签到功能也恢复正常。